### PR TITLE
Install Fortran modules.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -86,6 +86,10 @@ ecbuild_add_library( TARGET   gsw
                      LINKER_LANGUAGE ${GSW_LINKER_LANGUAGE}
                     )
 
+if(ECBUILD_INSTALL_FORTRAN_MODULES)
+  install(DIRECTORY ${CMAKE_Fortran_MODULE_DIRECTORY}/${CMAKE_CFG_INTDIR} DESTINATION ${INSTALL_INCLUDE_DIR} )
+endif()
+
 ################################################################################
 # Finalise configuration
 ################################################################################


### PR DESCRIPTION
Currently the Fortran modules are not installed when make install is run.  This means builds of ufo cannot find them in the install directory.  This change installs them.