### PR TITLE
squelch the annoying 'conversion' warnings when compiling in debug

### DIFF
--- a/cmake/compiler_flags_GNU_Fortran.cmake
+++ b/cmake/compiler_flags_GNU_Fortran.cmake
@@ -19,7 +19,7 @@ set( CMAKE_Fortran_FLAGS_RELEASE "-O3" )
 # DEBUG FLAGS
 ####################################################################
 
-set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g -Wall -Wconversion-extra" )
+set( CMAKE_Fortran_FLAGS_DEBUG   "-O0 -g -Wall" )
 
 ####################################################################
 # BIT REPRODUCIBLE FLAGS


### PR DESCRIPTION
When anything using GSW is compiled in debug mode, there are exactly **6,379** warnings generated due to the `-Wconversion-extra` flag being used.  This removes that flag, and makes the TravisCI output for ufo builds no longer maddening to have to sort through.