### PR TITLE
Add directory label for CDash

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,6 +4,8 @@ project( gsw VERSION 3.0.5 LANGUAGES Fortran )
 
 set( CMAKE_MODULE_PATH ${CMAKE_CURRENT_SOURCE_DIR}/cmake;${CMAKE_MODULE_PATH} )
 
+set( CMAKE_DIRECTORY_LABELS "gsw" )
+
 set( ECBUILD_DEFAULT_BUILD_TYPE Release )
 set( ENABLE_OS_TESTS           OFF CACHE BOOL "Disable OS tests" FORCE )
 set( ENABLE_LARGE_FILE_SUPPORT OFF CACHE BOOL "Disable testing of large file support" FORCE )


### PR DESCRIPTION
Adds in a single line to CMakeLists.txt allowing CDash dashboards to recognize gsw as a separate project within a bundle.

Basically, this allows us to separate gsw warnings and errors from the rest of the bundle.